### PR TITLE
MkIfex: use ifex_ite, delete some unuseds

### DIFF
--- a/MkIfex.thy
+++ b/MkIfex.thy
@@ -7,69 +7,29 @@ theory MkIfex
   imports "ROBDD.BDT"
 begin
 
-fun mk_ifex :: "'a boolfunc \<Rightarrow> 'a list \<Rightarrow> 'a ifex" where
-"mk_ifex f [] = (if f undefined then Trueif else Falseif)" |
-"mk_ifex f (v#vs) = IF v (mk_ifex (bf_restrict v True f) vs) (mk_ifex (bf_restrict v False f) vs)"
+fun mk_ifex :: "('a :: linorder) boolfunc \<Rightarrow> 'a list \<Rightarrow> 'a ifex" where
+"mk_ifex f [] = (if f (const False) then Trueif else Falseif)" |
+"mk_ifex f (v#vs) = ifex_ite (IF v Trueif Falseif) (mk_ifex (bf_restrict v True f) vs) (mk_ifex (bf_restrict v False f) vs)"
+
+lemma mk_ifex_ro: "ro_ifex (mk_ifex f vs)"
+  by(induction vs arbitrary: f; fastforce intro: order_ifex_ite_invar minimal_ifex_ite_invar simp del: ifex_ite.simps)
 
 definition "reads_inside_set f x \<equiv> (\<forall>assmt1 assmt2. (\<forall>p. p \<in> x \<longrightarrow> assmt1 p = assmt2 p) \<longrightarrow> f assmt1 = f assmt2)"
-definition "reads_finite f \<equiv> \<exists>x. finite x \<and> reads_inside_set f x"
 
 lemma reads_inside_set_subset: "reads_inside_set f a \<Longrightarrow> a \<subseteq> b \<Longrightarrow> reads_inside_set f b"
   unfolding reads_inside_set_def by blast
-
-lemma reads_inside_set_bf_vars: "reads_inside_set f x \<Longrightarrow> bf_vars f \<subseteq> x"
-  unfolding bf_vars_def reads_inside_set_def bf_restrict_def
-  apply(rule subsetI)
-  apply(unfold mem_Collect_eq)
-  apply(erule exE)
-  apply(metis fun_upd_apply) (* meh *)
-done
-
-lemma const_funcs_finite: "reads_finite bf_True" "reads_finite bf_False" unfolding reads_finite_def reads_inside_set_def by blast+
-lemma lit_finite: "reads_finite (bf_lit x)" unfolding bf_lit_def reads_finite_def reads_inside_set_def by blast
-lemma combine_funcs_finite:
-  assumes "reads_finite f1" "reads_finite f2" "reads_finite f3"
-  shows "reads_finite ((bf_ite f1 f2 f3) :: 'a boolfunc)"
-proof -
-  from assms(1)[unfolded reads_finite_def] guess r1 .. note r1 = this
-  from assms(2)[unfolded reads_finite_def] guess r2 .. note r2 = this
-  from assms(3)[unfolded reads_finite_def] guess r3 .. note r3 = this
-  define r where "r \<equiv> r1 \<union> r2 \<union> r3"
-  have rf: "finite r" using r1 r2 r3 r_def by simp
-  have re: "reads_inside_set f1 r" "reads_inside_set f2 r" "reads_inside_set f3 r"
-    using r1 r2 r3 r_def rf by(simp_all add: reads_inside_set_def)
-  thus ?thesis unfolding bf_ite_def reads_inside_set_def reads_finite_def by (metis rf)
-qed
-
-lemma restrict_reads_finite: "reads_finite (f :: 'a boolfunc) \<Longrightarrow> reads_finite (bf_restrict i v f)"
-(* opposite direction does not hold *)
-proof -
-  assume "reads_finite f" 
-  from this[unfolded reads_finite_def] guess a .. note a = this
-  hence "reads_inside_set (bf_restrict i v f) a" unfolding reads_inside_set_def bf_restrict_def by simp
-  thus "reads_finite (bf_restrict i v f)"  unfolding reads_finite_def using a by fast
-qed
 
 lemma reads_inside_set_restrict: "reads_inside_set f s \<Longrightarrow> reads_inside_set (bf_restrict i v f) (Set.remove i s)"
   unfolding reads_inside_set_def bf_restrict_def by force (* wow *)
 
 lemma collect_upd_true: "Collect (x(y:= True)) = insert y (Collect x)" by auto
 lemma collect_upd_false: "Collect (x(y:= False)) = Set.remove y (Collect x)" by auto metis
-  
-lemma "bf_vars (\<lambda>assmt. finite {x. assmt x}) = {}"
-  unfolding bf_vars_def Collect_empty_eq bf_restrict_def not_ex not_not collect_upd_true collect_upd_false remove_def
-  by simp
-
-lemma vars_restrict: "finite (bf_vars f) \<Longrightarrow> bf_vars (bf_restrict v x f) \<subseteq> Set.remove v (bf_vars f)"
-  apply(rule subsetI)
-  apply(subst Set.member_remove)
-  apply(rule)
-  subgoal unfolding bf_vars_def bf_restrict_def mem_Collect_eq by (metis (no_types, lifting) fun_upd_twist fun_upd_upd)
-  subgoal unfolding bf_vars_def bf_restrict_def by force
-  done
 
 lemma reads_none: "reads_inside_set f {} \<Longrightarrow> f = bf_True \<or> f = bf_False"
   unfolding reads_inside_set_def by fast (* wow *)
+
+lemma val_ifex_ite_subst: "\<lbrakk>ro_ifex i; ro_ifex t; ro_ifex e\<rbrakk> \<Longrightarrow> val_ifex (ifex_ite i t e) = bf_ite (val_ifex i) (val_ifex t) (val_ifex e)"
+  using val_ifex_ite by blast
 
 lemma 
   val_ifex_mk_ifex_equal:
@@ -83,7 +43,7 @@ next
     using reads_inside_set_restrict[OF Cons.prems] reads_inside_set_subset by fastforce
   from Cons.IH[OF this] show ?case 
     unfolding mk_ifex.simps val_ifex.simps bf_restrict_def
-    by (simp add: fun_upd_idem)
+    by(subst val_ifex_ite_subst; simp add: bf_ite_def fun_upd_idem mk_ifex_ro)
 qed
 
 end


### PR DESCRIPTION
Hi!

Feel free to use the file any way you want. (And thank you for adding my name.)

Though ultimately, I don't think this is the way. IIRC, there's no easy way to convert an ifex to a bdd. Also, once you have a boolfunc, you'll have a hard time converting it to a bdd in non-exponential time (Ifexes are beyond evil here, they're exponential space of the number of input variables).

I've stared at vec_lambda and friends for a while, and I'm still not sure what they do, so I don't think I can help you any further.
If you want this to be computable in reasonable time, I think what you want is to construct (RO)BDDs directly, without going through boolfunc, with a combination of `litci`, `andci`, `notci`, `fci`, …, e.g. like done here for propositional formulas.
https://github.com/jcaesar/isalol-afp-logic-links/blob/31f147973867fc025bc2651293251159a157646a/ROBDD_PPS_Formulas.thy#L7
Doing so will bring you into Peter Lammich's imparative monad, which you can't escape from. That's unavoidable with our BDDs. :/

PS: Is writing "if x ∈ y then False else True" somehow convenient for Isabelle's automation? I'd have guessed that "x ∉ y" would confuse simp less…